### PR TITLE
RouterFS: fix configs' "fromScheme" validation

### DIFF
--- a/src/main/java/io/lakefs/routerfs/PathMapper.java
+++ b/src/main/java/io/lakefs/routerfs/PathMapper.java
@@ -229,15 +229,20 @@ public class PathMapper {
             this.defaultMapping = defaultMapping;
             this.srcConfig = srcConfig;
             this.dstConfig = dstConfig;
-            if (!srcConfig.getFromScheme().equals(dstConfig.getFromScheme())) {
-                LOG.error("src and dst schemes must match, cannot create PathMapping. src:"
-                        + srcConfig.getFromScheme() + " dst: " + dstConfig.getFromScheme());
-            }
             this.fromScheme = srcConfig.getFromScheme();
+
             if (!this.defaultMapping) {
+                if (!srcConfig.getFromScheme().equals(dstConfig.getFromScheme())) {
+                    LOG.error("src and dst schemes must match, cannot create PathMapping. src: {}, dst: {}.",
+                            srcConfig.getFromScheme(),
+                            dstConfig.getFromScheme()
+                    );
+                }
                 if (srcConfig.getPriority() != dstConfig.getPriority()) {
-                    LOG.error("src and dst indices must match, cannot create PathMapping. src:"
-                            + srcConfig.getPriority() + " dst: " + dstConfig.getPriority());
+                    LOG.error("src and dst indices must match, cannot create PathMapping. src: {}, dst: {}.",
+                            srcConfig.getPriority(),
+                            dstConfig.getPriority()
+                    );
                 }
                 this.priority = srcConfig.getPriority();
             }


### PR DESCRIPTION
When configuring the default mapping for RouterFS, the `fromScheme`s of the source and destinations configurations will be different.
For example, `routerfs.default.fs.s3a=S3AFileSystem` will result in the following mapping:
```
srcConfig: <SOURCE, null, **s3a**, s3a://>
dstConfig: <DEST, null, **s3a-default**, s3a-default://>
priority: NULL
fromScheme: s3a
defaultMapping: true
```

This is different than the regular process of mapping in which the `fromScheme` of both mappings (`replace` and `with`) will be the same, for example:
```configuration
routerfs.mapping.s3a.1.replace=s3a://bucket/dir1/
routerfs.mapping.s3a.1.with=lakefs://repo/main/
```
Will result in:
```
srcConfig: <SOURCE, 1, **s3a**, s3a://bucket/dir1/>
dstConfig: <DEST, 1, **s3a**, lakefs://repo/main/>
priority: 1
fromScheme: s3a
defaultMapping: false
```